### PR TITLE
BUGFIX: Fix driver Makefile to work with Vitis (Windows)

### DIFF
--- a/drivers/fpga_base/src/Makefile
+++ b/drivers/fpga_base/src/Makefile
@@ -11,16 +11,17 @@ INCLUDES=-I./. -I${INCLUDEDIR}
 
 INCLUDEFILES=*.h
 LIBSOURCES=*.c
-OUTS = *.o
+OBJECTS = $(addsuffix .o, $(basename $(wildcard *.c)))
+ASSEMBLY_OBJECTS = $(addsuffix .o, $(basename $(wildcard *.S)))
 
 libs:
 	echo "Compiling fpga_base..."
 	$(COMPILER) $(COMPILER_FLAGS) $(EXTRA_COMPILER_FLAGS) $(INCLUDES) $(LIBSOURCES)
-	$(ARCHIVER) -r ${RELEASEDIR}/${LIB} ${OUTS}
+	$(ARCHIVER) -r ${RELEASEDIR}/${LIB} ${OBJECTS} ${ASSEMBLY_OBJECTS}
 	make clean
 
 include:
 	${CP} $(INCLUDEFILES) $(INCLUDEDIR)
 
 clean:
-	-@rm -rf ${OUTS} 
+	-@rm -rf ${OBJECTS} ${ASSEMBLY_OBJECTS}


### PR DESCRIPTION
This pull request will fix issue #1 .
The fix is tested with Vitis 2020.1 in combination with the axi_parameter_ram and the vivadoIP_spi_simple.
The modifications are proposed to all IP cores to be consistent.